### PR TITLE
手動スクレイピング時にもメール通知を送信するように変更

### DIFF
--- a/backend/src/main/java/com/example/capsuletoy/repository/ProductRepository.java
+++ b/backend/src/main/java/com/example/capsuletoy/repository/ProductRepository.java
@@ -22,6 +22,9 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     // 新着商品のみ取得
     List<Product> findByIsNewTrue();
 
+    // メーカー別の新着商品を取得
+    List<Product> findByIsNewTrueAndManufacturer(String manufacturer);
+
     // 新着商品のみ取得（ページネーション対応）
     Page<Product> findByIsNewTrue(Pageable pageable);
 


### PR DESCRIPTION
- ScrapeControllerにNotificationServiceを追加
- 手動スクレイピング後、新着商品があればメール通知を送信
- ProductRepositoryにメーカー別新着商品取得メソッドを追加