### PR TITLE
ユーザー詳細編集ページを追加

### DIFF
--- a/backend/src/main/java/com/example/capsuletoy/controller/AdminUserController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/AdminUserController.java
@@ -63,6 +63,36 @@ public class AdminUserController {
         }
     }
 
+    // ユーザー詳細取得
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getUser(@PathVariable Long id) {
+        try {
+            User user = userService.findById(id);
+            return ResponseEntity.ok(toUserMap(user));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    // ユーザー更新
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateUser(@PathVariable Long id, @RequestBody UpdateUserRequest request) {
+        try {
+            User user = userService.updateUser(
+                    id,
+                    request.getUsername(),
+                    request.getEmail(),
+                    request.getPassword(),
+                    request.getNotificationEnabled()
+            );
+            return ResponseEntity.ok(toUserMap(user));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+
     private Map<String, Object> toUserMap(User user) {
         Map<String, Object> map = new HashMap<>();
         map.put("id", user.getId());
@@ -89,5 +119,21 @@ public class AdminUserController {
         public void setPassword(String password) { this.password = password; }
         public String getRole() { return role; }
         public void setRole(String role) { this.role = role; }
+    }
+
+    static class UpdateUserRequest {
+        private String username;
+        private String email;
+        private String password;
+        private Boolean notificationEnabled;
+
+        public String getUsername() { return username; }
+        public void setUsername(String username) { this.username = username; }
+        public String getEmail() { return email; }
+        public void setEmail(String email) { this.email = email; }
+        public String getPassword() { return password; }
+        public void setPassword(String password) { this.password = password; }
+        public Boolean getNotificationEnabled() { return notificationEnabled; }
+        public void setNotificationEnabled(Boolean notificationEnabled) { this.notificationEnabled = notificationEnabled; }
     }
 }

--- a/backend/src/main/java/com/example/capsuletoy/service/UserService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/UserService.java
@@ -84,4 +84,43 @@ public class UserService implements UserDetailsService {
         }
         userRepository.deleteById(id);
     }
+
+    // IDでユーザー取得
+    public User findById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found: ID=" + id));
+    }
+
+    // ユーザー更新
+    public User updateUser(Long id, String username, String email, String password, Boolean notificationEnabled) {
+        User user = findById(id);
+
+        // ユーザー名の重複チェック（自分以外）
+        if (username != null && !username.equals(user.getUsername())) {
+            if (userRepository.existsByUsername(username)) {
+                throw new RuntimeException("Username already exists");
+            }
+            user.setUsername(username);
+        }
+
+        // メールアドレスの重複チェック（自分以外）
+        if (email != null && !email.equals(user.getEmail())) {
+            if (userRepository.existsByEmail(email)) {
+                throw new RuntimeException("Email already exists");
+            }
+            user.setEmail(email);
+        }
+
+        // パスワード更新（空でなければ）
+        if (password != null && !password.isEmpty()) {
+            user.setPasswordHash(passwordEncoder.encode(password));
+        }
+
+        // 通知設定更新
+        if (notificationEnabled != null) {
+            user.setNotificationEnabled(notificationEnabled);
+        }
+
+        return userRepository.save(user);
+    }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import AdminScrape from './pages/AdminScrape'
 import AdminLogs from './pages/AdminLogs'
 // AdminSites removed - sites are predefined
 import AdminUsers from './pages/AdminUsers'
+import AdminUserDetail from './pages/AdminUserDetail'
 import AdminProtectedRoute from './components/AdminProtectedRoute'
 
 function Navigation() {
@@ -146,6 +147,7 @@ function AppContent() {
           <Route path="/admin/scrape" element={<AdminProtectedRoute><AdminScrape /></AdminProtectedRoute>} />
           <Route path="/admin/logs" element={<AdminProtectedRoute><AdminLogs /></AdminProtectedRoute>} />
           <Route path="/admin/users" element={<AdminProtectedRoute><AdminUsers /></AdminProtectedRoute>} />
+          <Route path="/admin/users/:id" element={<AdminProtectedRoute><AdminUserDetail /></AdminProtectedRoute>} />
         </Routes>
       </main>
     </div>

--- a/frontend/src/pages/AdminUserDetail.tsx
+++ b/frontend/src/pages/AdminUserDetail.tsx
@@ -1,0 +1,244 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { getUser, updateUser } from '../services/adminApi';
+
+interface UserInfo {
+  id: number;
+  username: string;
+  email: string;
+  role: string;
+  notificationEnabled: boolean;
+  createdAt: string;
+}
+
+function AdminUserDetail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [user, setUser] = useState<UserInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [formData, setFormData] = useState({
+    username: '',
+    email: '',
+    password: '',
+    notificationEnabled: false,
+  });
+  const [formError, setFormError] = useState('');
+  const [formLoading, setFormLoading] = useState(false);
+  const [success, setSuccess] = useState('');
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      if (!id) return;
+      try {
+        setLoading(true);
+        const data = await getUser(parseInt(id));
+        setUser(data);
+        setFormData({
+          username: data.username,
+          email: data.email,
+          password: '',
+          notificationEnabled: data.notificationEnabled,
+        });
+      } catch (err) {
+        setError('ユーザー情報の取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchUser();
+  }, [id]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!id) return;
+
+    setFormLoading(true);
+    setFormError('');
+    setSuccess('');
+
+    try {
+      const updateData: {
+        username?: string;
+        email?: string;
+        password?: string;
+        notificationEnabled?: boolean;
+      } = {
+        username: formData.username,
+        email: formData.email,
+        notificationEnabled: formData.notificationEnabled,
+      };
+
+      // パスワードは入力された場合のみ送信
+      if (formData.password) {
+        updateData.password = formData.password;
+      }
+
+      const updatedUser = await updateUser(parseInt(id), updateData);
+      setUser(updatedUser);
+      setFormData({
+        ...formData,
+        password: '',
+      });
+      setSuccess('ユーザー情報を更新しました');
+    } catch (err: any) {
+      setFormError(err.response?.data?.error || 'ユーザー情報の更新に失敗しました');
+    } finally {
+      setFormLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-gray-500">読み込み中...</div>
+      </div>
+    );
+  }
+
+  if (error || !user) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <div className="container mx-auto px-4 py-8 max-w-2xl">
+          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-4">
+            {error || 'ユーザーが見つかりません'}
+          </div>
+          <Link
+            to="/admin/users"
+            className="text-indigo-600 hover:text-indigo-800 text-sm font-medium"
+          >
+            ユーザー一覧に戻る
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 max-w-2xl">
+        {/* ヘッダー */}
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8 gap-4">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">ユーザー編集</h1>
+            <p className="text-gray-600 mt-1">ID: {user.id}</p>
+          </div>
+          <Link
+            to="/admin/users"
+            className="bg-gray-200 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-300 transition text-sm font-medium"
+          >
+            ユーザー一覧に戻る
+          </Link>
+        </div>
+
+        {/* フォーム */}
+        <div className="bg-white rounded-lg shadow-md p-6">
+          {formError && (
+            <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+              {formError}
+            </div>
+          )}
+          {success && (
+            <div className="mb-4 bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg text-sm">
+              {success}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                ユーザー名
+              </label>
+              <input
+                type="text"
+                value={formData.username}
+                onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none text-sm"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                メールアドレス
+              </label>
+              <input
+                type="email"
+                value={formData.email}
+                onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none text-sm"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                パスワード
+              </label>
+              <input
+                type="password"
+                value={formData.password}
+                onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                placeholder="変更する場合のみ入力（8文字以上）"
+                minLength={8}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none text-sm"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                空欄の場合、パスワードは変更されません
+              </p>
+            </div>
+
+            <div>
+              <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={formData.notificationEnabled}
+                  onChange={(e) => setFormData({ ...formData, notificationEnabled: e.target.checked })}
+                  className="w-5 h-5 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                />
+                <span className="text-sm font-medium text-gray-700">
+                  メール通知を有効にする
+                </span>
+              </label>
+              <p className="mt-1 text-xs text-gray-500 ml-8">
+                有効にすると、スクレイピング完了時にメール通知が届きます
+              </p>
+            </div>
+
+            <div className="flex items-center gap-4 pt-4 border-t border-gray-200">
+              <button
+                type="submit"
+                disabled={formLoading}
+                className="bg-indigo-600 text-white px-6 py-2 rounded-lg hover:bg-indigo-700 transition text-sm font-medium disabled:opacity-50"
+              >
+                {formLoading ? '更新中...' : '更新する'}
+              </button>
+              <span className="text-sm text-gray-500">
+                ロール: <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                  user.role === 'ADMIN'
+                    ? 'bg-purple-100 text-purple-800'
+                    : 'bg-green-100 text-green-800'
+                }`}>
+                  {user.role === 'ADMIN' ? '管理者' : '一般'}
+                </span>
+              </span>
+            </div>
+          </form>
+
+          {/* 追加情報 */}
+          <div className="mt-6 pt-6 border-t border-gray-200">
+            <h3 className="text-sm font-medium text-gray-700 mb-2">その他の情報</h3>
+            <dl className="text-sm text-gray-600 space-y-1">
+              <div className="flex gap-2">
+                <dt className="font-medium">作成日:</dt>
+                <dd>{new Date(user.createdAt).toLocaleString('ja-JP')}</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AdminUserDetail;

--- a/frontend/src/pages/AdminUsers.tsx
+++ b/frontend/src/pages/AdminUsers.tsx
@@ -187,6 +187,7 @@ function AdminUsers() {
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ユーザー名</th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">メール</th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ロール</th>
+                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">通知</th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">作成日</th>
                     <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">操作</th>
                   </tr>
@@ -206,16 +207,33 @@ function AdminUsers() {
                           {user.role === 'ADMIN' ? '管理者' : '一般'}
                         </span>
                       </td>
+                      <td className="px-6 py-4">
+                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                          user.notificationEnabled
+                            ? 'bg-blue-100 text-blue-800'
+                            : 'bg-gray-100 text-gray-500'
+                        }`}>
+                          {user.notificationEnabled ? 'ON' : 'OFF'}
+                        </span>
+                      </td>
                       <td className="px-6 py-4 text-sm text-gray-600">
                         {new Date(user.createdAt).toLocaleDateString('ja-JP')}
                       </td>
                       <td className="px-6 py-4">
-                        <button
-                          onClick={() => handleDelete(user.id, user.username)}
-                          className="text-red-600 hover:text-red-800 text-sm font-medium transition"
-                        >
-                          削除
-                        </button>
+                        <div className="flex items-center gap-3">
+                          <Link
+                            to={`/admin/users/${user.id}`}
+                            className="text-indigo-600 hover:text-indigo-800 text-sm font-medium transition"
+                          >
+                            編集
+                          </Link>
+                          <button
+                            onClick={() => handleDelete(user.id, user.username)}
+                            className="text-red-600 hover:text-red-800 text-sm font-medium transition"
+                          >
+                            削除
+                          </button>
+                        </div>
                       </td>
                     </tr>
                   ))}

--- a/frontend/src/services/adminApi.ts
+++ b/frontend/src/services/adminApi.ts
@@ -70,6 +70,23 @@ export const getUsers = async () => {
   return response.data;
 };
 
+// ユーザー詳細取得
+export const getUser = async (id: number) => {
+  const response = await api.get(`/admin/users/${id}`);
+  return response.data;
+};
+
+// ユーザー更新
+export const updateUser = async (id: number, data: {
+  username?: string;
+  email?: string;
+  password?: string;
+  notificationEnabled?: boolean;
+}) => {
+  const response = await api.put(`/admin/users/${id}`, data);
+  return response.data;
+};
+
 // ユーザー作成
 export const createUser = async (data: {
   username: string;


### PR DESCRIPTION
バックエンド:
- UserService: findById(), updateUser() メソッドを追加
- AdminUserController: GET/PUT /api/admin/users/{id} エンドポイントを追加

フロントエンド:
- adminApi.ts: getUser(), updateUser() を追加
- AdminUserDetail.tsx: ユーザー編集ページを新規作成
  - ユーザー名、メールアドレス、パスワード、通知ON/OFFを編集可能
- App.tsx: /admin/users/:id ルートを追加
- AdminUsers.tsx: 編集リンクと通知状態カラムを追加