### PR TITLE
新着0件でもスクレイピング完了通知メールを送信するように修正

### DIFF
--- a/backend/src/main/java/com/example/capsuletoy/controller/ScrapeController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/ScrapeController.java
@@ -55,17 +55,13 @@ public class ScrapeController {
         try {
             ScrapeService.ScrapeResult result = scrapeService.executeScraping(bandaiScraper, "BANDAI_GASHAPON");
 
-            // 新着商品があれば通知を送信
-            if (result.newProducts() > 0) {
-                List<Product> newProducts = productRepository.findByIsNewTrueAndManufacturer("BANDAI");
-                if (!newProducts.isEmpty()) {
-                    try {
-                        notificationService.notifyNewProducts(newProducts);
-                        logger.info("新着商品{}件の通知メールを送信しました", newProducts.size());
-                    } catch (Exception e) {
-                        logger.error("通知メール送信中にエラー: {}", e.getMessage(), e);
-                    }
-                }
+            // スクレイピング完了後に通知を送信（新着0件でも送信）
+            List<Product> newProducts = productRepository.findByIsNewTrueAndManufacturer("BANDAI");
+            try {
+                notificationService.notifyNewProducts(newProducts);
+                logger.info("通知メールを送信しました（新着{}件）", newProducts.size());
+            } catch (Exception e) {
+                logger.error("通知メール送信中にエラー: {}", e.getMessage(), e);
             }
 
             Map<String, Object> response = new HashMap<>();
@@ -100,17 +96,13 @@ public class ScrapeController {
         try {
             ScrapeService.ScrapeResult result = scrapeService.executeScraping(takaraTomyScraper, "TAKARA_TOMY_ARTS");
 
-            // 新着商品があれば通知を送信
-            if (result.newProducts() > 0) {
-                List<Product> newProducts = productRepository.findByIsNewTrueAndManufacturer("TAKARA_TOMY");
-                if (!newProducts.isEmpty()) {
-                    try {
-                        notificationService.notifyNewProducts(newProducts);
-                        logger.info("新着商品{}件の通知メールを送信しました", newProducts.size());
-                    } catch (Exception e) {
-                        logger.error("通知メール送信中にエラー: {}", e.getMessage(), e);
-                    }
-                }
+            // スクレイピング完了後に通知を送信（新着0件でも送信）
+            List<Product> newProducts = productRepository.findByIsNewTrueAndManufacturer("TAKARA_TOMY");
+            try {
+                notificationService.notifyNewProducts(newProducts);
+                logger.info("通知メールを送信しました（新着{}件）", newProducts.size());
+            } catch (Exception e) {
+                logger.error("通知メール送信中にエラー: {}", e.getMessage(), e);
             }
 
             Map<String, Object> response = new HashMap<>();

--- a/backend/src/main/java/com/example/capsuletoy/service/ScheduledScrapeService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/ScheduledScrapeService.java
@@ -85,14 +85,12 @@ public class ScheduledScrapeService {
             }
         }
 
-        // 新着商品があれば通知メールを送信
-        if (!allNewProducts.isEmpty()) {
-            logger.info("新着商品{}件を通知します", allNewProducts.size());
-            try {
-                notificationService.notifyNewProducts(allNewProducts);
-            } catch (Exception e) {
-                logger.error("通知メール送信中にエラー: {}", e.getMessage(), e);
-            }
+        // スクレイピング完了後に通知メールを送信（新着0件でも送信）
+        logger.info("通知メールを送信します（新着{}件）", allNewProducts.size());
+        try {
+            notificationService.notifyNewProducts(allNewProducts);
+        } catch (Exception e) {
+            logger.error("通知メール送信中にエラー: {}", e.getMessage(), e);
         }
 
         logger.info("=== 定期スクレイピング終了 ===");


### PR DESCRIPTION
ScrapeControllerとScheduledScrapeServiceで新着商品が0件の場合に 通知メール送信がスキップされていた問題を修正。
if条件を削除し、常にnotifyNewProductsを呼び出すようにした。