### PR TITLE
ユーザー自身のプロフィール編集ページを追加

### DIFF
--- a/backend/src/main/java/com/example/capsuletoy/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/capsuletoy/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers("/api/products/**").permitAll()
                 .requestMatchers("/actuator/**").permitAll()
+                .requestMatchers("/api/profile/**").authenticated()
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                 .requestMatchers("/api/scrape/**").hasRole("ADMIN")
                 .requestMatchers("/api/notifications/**").hasRole("ADMIN")

--- a/backend/src/main/java/com/example/capsuletoy/controller/ProfileController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/ProfileController.java
@@ -1,0 +1,79 @@
+package com.example.capsuletoy.controller;
+
+import com.example.capsuletoy.model.User;
+import com.example.capsuletoy.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/profile")
+public class ProfileController {
+
+    @Autowired
+    private UserService userService;
+
+    // 自分のプロフィール取得
+    @GetMapping
+    public ResponseEntity<?> getProfile(Authentication authentication) {
+        try {
+            String email = authentication.getName();
+            User user = userService.findByEmail(email);
+            return ResponseEntity.ok(buildUserResponse(user));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "プロフィールの取得に失敗しました"));
+        }
+    }
+
+    // 自分のプロフィール更新
+    @PutMapping
+    public ResponseEntity<?> updateProfile(Authentication authentication, @RequestBody UpdateProfileRequest request) {
+        try {
+            String email = authentication.getName();
+            User user = userService.findByEmail(email);
+
+            User updatedUser = userService.updateUser(
+                    user.getId(),
+                    request.getUsername(),
+                    request.getEmail(),
+                    request.getPassword(),
+                    request.getNotificationEnabled()
+            );
+
+            return ResponseEntity.ok(buildUserResponse(updatedUser));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    private Map<String, Object> buildUserResponse(User user) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("id", user.getId());
+        response.put("username", user.getUsername());
+        response.put("email", user.getEmail());
+        response.put("role", user.getRole().name());
+        response.put("notificationEnabled", user.getNotificationEnabled());
+        response.put("createdAt", user.getCreatedAt().toString());
+        return response;
+    }
+
+    static class UpdateProfileRequest {
+        private String username;
+        private String email;
+        private String password;
+        private Boolean notificationEnabled;
+
+        public String getUsername() { return username; }
+        public void setUsername(String username) { this.username = username; }
+        public String getEmail() { return email; }
+        public void setEmail(String email) { this.email = email; }
+        public String getPassword() { return password; }
+        public void setPassword(String password) { this.password = password; }
+        public Boolean getNotificationEnabled() { return notificationEnabled; }
+        public void setNotificationEnabled(Boolean notificationEnabled) { this.notificationEnabled = notificationEnabled; }
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import AdminLogs from './pages/AdminLogs'
 // AdminSites removed - sites are predefined
 import AdminUsers from './pages/AdminUsers'
 import AdminUserDetail from './pages/AdminUserDetail'
+import Profile from './pages/Profile'
 import AdminProtectedRoute from './components/AdminProtectedRoute'
 
 function Navigation() {
@@ -59,12 +60,12 @@ function Navigation() {
           <div className="hidden md:flex items-center space-x-4">
             {isAdmin && user && (
               <>
-                <span className="text-gray-700 text-sm">
+                <Link to="/profile" className="text-gray-700 hover:text-indigo-600 text-sm transition">
                   {user.username}
                   <span className="ml-1 text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded-full">
                     管理者
                   </span>
-                </span>
+                </Link>
                 <button
                   onClick={handleLogout}
                   className="bg-red-500 text-white px-4 py-2 rounded-lg hover:bg-red-600 transition text-sm"
@@ -113,9 +114,9 @@ function Navigation() {
               {isAdmin && user && (
                 <div className="border-t border-gray-200 pt-2 mt-2">
                   <div className="flex flex-col space-y-2">
-                    <span className="text-gray-500 text-sm">
+                    <Link to="/profile" onClick={closeMenu} className="text-gray-700 hover:text-indigo-600 text-sm font-medium py-2 transition">
                       {user.username} (管理者)
-                    </span>
+                    </Link>
                     <button
                       onClick={handleLogout}
                       className="bg-red-500 text-white px-4 py-2 rounded-lg hover:bg-red-600 transition text-sm text-center"
@@ -142,6 +143,7 @@ function AppContent() {
           <Route path="/" element={<Home />} />
           <Route path="/products" element={<Products />} />
           <Route path="/about" element={<About />} />
+          <Route path="/profile" element={<AdminProtectedRoute><Profile /></AdminProtectedRoute>} />
           <Route path="/admin/login" element={<AdminLogin />} />
           <Route path="/admin" element={<AdminProtectedRoute><AdminDashboard /></AdminProtectedRoute>} />
           <Route path="/admin/scrape" element={<AdminProtectedRoute><AdminScrape /></AdminProtectedRoute>} />

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -6,6 +6,7 @@ interface AuthContextType {
   token: string | null;
   login: (token: string, user: User) => void;
   logout: () => void;
+  updateUser: (user: User) => void;
   isAuthenticated: boolean;
 }
 
@@ -39,11 +40,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null);
   };
 
+  const updateUser = (updatedUser: User) => {
+    localStorage.setItem('user', JSON.stringify(updatedUser));
+    setUser(updatedUser);
+  };
+
   const value = {
     user,
     token,
     login,
     logout,
+    updateUser,
     isAuthenticated: !!token && !!user,
   };
 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,0 +1,208 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { getProfile, updateProfile } from '../services/api';
+
+function Profile() {
+  const { user, updateUser } = useAuth();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+  const [formData, setFormData] = useState({
+    username: '',
+    email: '',
+    password: '',
+    notificationEnabled: false,
+  });
+  const [formError, setFormError] = useState('');
+  const [formLoading, setFormLoading] = useState(false);
+  const [success, setSuccess] = useState('');
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        setLoading(true);
+        const data = await getProfile();
+        setFormData({
+          username: data.username,
+          email: data.email,
+          password: '',
+          notificationEnabled: data.notificationEnabled,
+        });
+      } catch {
+        setFormError('プロフィールの取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchProfile();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormLoading(true);
+    setFormError('');
+    setSuccess('');
+
+    try {
+      const updateData: {
+        username?: string;
+        email?: string;
+        password?: string;
+        notificationEnabled?: boolean;
+      } = {
+        username: formData.username,
+        email: formData.email,
+        notificationEnabled: formData.notificationEnabled,
+      };
+
+      if (formData.password) {
+        updateData.password = formData.password;
+      }
+
+      const updatedUser = await updateProfile(updateData);
+      updateUser(updatedUser);
+      setFormData({
+        ...formData,
+        password: '',
+      });
+      setSuccess('プロフィールを更新しました');
+    } catch (err: any) {
+      setFormError(err.response?.data?.error || 'プロフィールの更新に失敗しました');
+    } finally {
+      setFormLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-gray-500">読み込み中...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8 max-w-2xl">
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8 gap-4">
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900">プロフィール編集</h1>
+            <p className="text-gray-600 mt-1">{user?.username} さんの設定</p>
+          </div>
+          <button
+            onClick={() => navigate(-1)}
+            className="bg-gray-200 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-300 transition text-sm font-medium"
+          >
+            戻る
+          </button>
+        </div>
+
+        <div className="bg-white rounded-lg shadow-md p-6">
+          {formError && (
+            <div className="mb-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
+              {formError}
+            </div>
+          )}
+          {success && (
+            <div className="mb-4 bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-lg text-sm">
+              {success}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                ユーザー名
+              </label>
+              <input
+                type="text"
+                value={formData.username}
+                onChange={(e) => setFormData({ ...formData, username: e.target.value })}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none text-sm"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                メールアドレス
+              </label>
+              <input
+                type="email"
+                value={formData.email}
+                onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none text-sm"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                パスワード
+              </label>
+              <input
+                type="password"
+                value={formData.password}
+                onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                placeholder="変更する場合のみ入力（8文字以上）"
+                minLength={8}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none text-sm"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                空欄の場合、パスワードは変更されません
+              </p>
+            </div>
+
+            <div>
+              <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={formData.notificationEnabled}
+                  onChange={(e) => setFormData({ ...formData, notificationEnabled: e.target.checked })}
+                  className="w-5 h-5 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
+                />
+                <span className="text-sm font-medium text-gray-700">
+                  メール通知を有効にする
+                </span>
+              </label>
+              <p className="mt-1 text-xs text-gray-500 ml-8">
+                有効にすると、スクレイピング完了時にメール通知が届きます
+              </p>
+            </div>
+
+            <div className="flex items-center gap-4 pt-4 border-t border-gray-200">
+              <button
+                type="submit"
+                disabled={formLoading}
+                className="bg-indigo-600 text-white px-6 py-2 rounded-lg hover:bg-indigo-700 transition text-sm font-medium disabled:opacity-50"
+              >
+                {formLoading ? '更新中...' : '更新する'}
+              </button>
+              <span className="text-sm text-gray-500">
+                ロール: <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                  user?.role === 'ADMIN'
+                    ? 'bg-purple-100 text-purple-800'
+                    : 'bg-green-100 text-green-800'
+                }`}>
+                  {user?.role === 'ADMIN' ? '管理者' : '一般'}
+                </span>
+              </span>
+            </div>
+          </form>
+
+          <div className="mt-6 pt-6 border-t border-gray-200">
+            <h3 className="text-sm font-medium text-gray-700 mb-2">アカウント情報</h3>
+            <dl className="text-sm text-gray-600 space-y-1">
+              <div className="flex gap-2">
+                <dt className="font-medium">作成日:</dt>
+                <dd>{user?.createdAt ? new Date(user.createdAt).toLocaleString('ja-JP') : '-'}</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Profile;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -48,4 +48,21 @@ api.interceptors.response.use(
   }
 );
 
+// プロフィール取得
+export const getProfile = async () => {
+  const response = await api.get('/profile');
+  return response.data;
+};
+
+// プロフィール更新
+export const updateProfile = async (data: {
+  username?: string;
+  email?: string;
+  password?: string;
+  notificationEnabled?: boolean;
+}) => {
+  const response = await api.put('/profile', data);
+  return response.data;
+};
+
 export default api;


### PR DESCRIPTION
- ProfileController: /api/profile エンドポイント（GET/PUT）を新規作成
- SecurityConfig: /api/profile/** を認証済みユーザーに許可
- Profile.tsx: プロフィール編集ページを新規作成
- AuthContext: updateUser関数を追加（ローカルストレージ同期）
- api.ts: getProfile/updateProfile関数を追加
- App.tsx: ナビゲーションのユーザー名をプロフィールページへのリンクに変更