### PR TITLE
DIをコンストラクタインジェクションに統一し不要な@Repositoryを削除

### DIFF
--- a/backend/src/main/java/com/example/capsuletoy/config/AdminInitializer.java
+++ b/backend/src/main/java/com/example/capsuletoy/config/AdminInitializer.java
@@ -6,7 +6,6 @@ import com.example.capsuletoy.service.user.UserCreateService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -17,11 +16,9 @@ public class AdminInitializer implements ApplicationRunner {
 
     private static final Logger logger = LoggerFactory.getLogger(AdminInitializer.class);
 
-    @Autowired
-    private UserCreateService userCreateService;
+    private final UserCreateService userCreateService;
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
     @Value("${admin.username:admin}")
     private String adminUsername;
@@ -31,6 +28,11 @@ public class AdminInitializer implements ApplicationRunner {
 
     @Value("${admin.email:admin@gachahub.com}")
     private String adminEmail;
+
+    AdminInitializer(UserCreateService userCreateService, UserRepository userRepository) {
+        this.userCreateService = userCreateService;
+        this.userRepository = userRepository;
+    }
 
     @Override
     public void run(ApplicationArguments args) {

--- a/backend/src/main/java/com/example/capsuletoy/config/ScrapeConfigInitializer.java
+++ b/backend/src/main/java/com/example/capsuletoy/config/ScrapeConfigInitializer.java
@@ -5,7 +5,6 @@ import com.example.capsuletoy.repository.ScrapeConfigRepository;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
@@ -15,8 +14,11 @@ public class ScrapeConfigInitializer implements ApplicationRunner {
 
     private static final Logger logger = LoggerFactory.getLogger(ScrapeConfigInitializer.class);
 
-    @Autowired
-    private ScrapeConfigRepository scrapeConfigRepository;
+    private final ScrapeConfigRepository scrapeConfigRepository;
+
+    public ScrapeConfigInitializer(ScrapeConfigRepository scrapeConfigRepository) {
+        this.scrapeConfigRepository = scrapeConfigRepository;
+    }
 
     @Override
     public void run(ApplicationArguments args) {

--- a/backend/src/main/java/com/example/capsuletoy/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/capsuletoy/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.example.capsuletoy.config;
 import com.example.capsuletoy.security.JwtAuthenticationFilter;
 import com.example.capsuletoy.service.user.UserService;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,14 +28,18 @@ public class SecurityConfig {
     @Value("${cors.allowed-origins:http://localhost:3000}")
     private String corsAllowedOrigins;
 
-    @Autowired
-    private UserService userService;
+    private final UserService userService;
 
-    @Autowired
-    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    @Autowired
-    private BCryptPasswordEncoder passwordEncoder;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public SecurityConfig(UserService userService, JwtAuthenticationFilter jwtAuthenticationFilter,
+            BCryptPasswordEncoder passwordEncoder) {
+        this.userService = userService;
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.passwordEncoder = passwordEncoder;
+    }
 
     @Bean
     public DaoAuthenticationProvider authenticationProvider() {

--- a/backend/src/main/java/com/example/capsuletoy/controller/auth/AuthController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/auth/AuthController.java
@@ -3,7 +3,6 @@ package com.example.capsuletoy.controller.auth;
 import com.example.capsuletoy.request.user.LoginRequest;
 import com.example.capsuletoy.service.auth.AuthService;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
@@ -17,8 +16,11 @@ import java.util.Map;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    @Autowired
-    private AuthService authService;
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
 
     // 管理者専用ログイン
     @PostMapping("/admin/login")

--- a/backend/src/main/java/com/example/capsuletoy/controller/notification/NotificationController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/notification/NotificationController.java
@@ -3,7 +3,6 @@ package com.example.capsuletoy.controller.notification;
 import com.example.capsuletoy.model.User;
 import com.example.capsuletoy.service.notification.NotificationService;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
@@ -19,8 +18,11 @@ import java.util.Map;
 @RequestMapping("/api/notifications")
 @CrossOrigin(origins = "http://localhost:3000")
 public class NotificationController {
-    @Autowired
-    private NotificationService notificationService;
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
 
     /**
      * テストメール送信

--- a/backend/src/main/java/com/example/capsuletoy/controller/product/ProductController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/product/ProductController.java
@@ -7,7 +7,6 @@ import com.example.capsuletoy.service.product.ProductService;
 
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -23,11 +22,14 @@ import org.springframework.web.bind.annotation.*;
 @CrossOrigin(origins = "http://localhost:3000")
 public class ProductController {
 
-    @Autowired
-    private ProductService productService;
+    private final ProductService productService;
 
-    @Autowired
-    private ProductPagenationService productPagenationService;
+    private final ProductPagenationService productPagenationService;
+
+    public ProductController(ProductService productService, ProductPagenationService productPagenationService) {
+        this.productService = productService;
+        this.productPagenationService = productPagenationService;
+    }
 
     /**
      * 商品一覧取得（ページネーション・フィルタ・ソート対応）

--- a/backend/src/main/java/com/example/capsuletoy/controller/scrape/BandaiScrapeController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/scrape/BandaiScrapeController.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,17 +24,21 @@ import com.example.capsuletoy.service.scraping.ScrapeService;
 public class BandaiScrapeController {
     private static final Logger logger = LoggerFactory.getLogger(BandaiScrapeController.class);
 
-    @Autowired
-    private ProductRepository productRepository;
+    private final ProductRepository productRepository;
 
-    @Autowired
-    private BandaiScraper bandaiScraper;
+    private final BandaiScraper bandaiScraper;
 
-    @Autowired
-    private ScrapeService scrapeService;
+    private final ScrapeService scrapeService;
 
-    @Autowired
-    private NotificationService notificationService;
+    private final NotificationService notificationService;
+
+    public BandaiScrapeController(ProductRepository productRepository, BandaiScraper bandaiScraper,
+            ScrapeService scrapeService, NotificationService notificationService) {
+        this.productRepository = productRepository;
+        this.bandaiScraper = bandaiScraper;
+        this.scrapeService = scrapeService;
+        this.notificationService = notificationService;
+    }
 
     /**
      * バンダイサイトのスクレイピングを手動実行

--- a/backend/src/main/java/com/example/capsuletoy/controller/scrape/TakaratomyScrapeController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/scrape/TakaratomyScrapeController.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,17 +26,21 @@ public class TakaratomyScrapeController {
 
     private static final Logger logger = LoggerFactory.getLogger(TakaratomyScrapeController.class);
 
-    @Autowired
-    private ScrapeService scrapeService;
+    private final ScrapeService scrapeService;
 
-    @Autowired
-    private NotificationService notificationService;
+    private final NotificationService notificationService;
 
-    @Autowired
-    private ProductRepository productRepository;
+    private final ProductRepository productRepository;
 
-    @Autowired
-    private TakaraTomyScraper takaraTomyScraper;
+    private final TakaraTomyScraper takaraTomyScraper;
+
+    public TakaratomyScrapeController(ScrapeService scrapeService, NotificationService notificationService,
+            ProductRepository productRepository, TakaraTomyScraper takaraTomyScraper) {
+        this.scrapeService = scrapeService;
+        this.notificationService = notificationService;
+        this.productRepository = productRepository;
+        this.takaraTomyScraper = takaraTomyScraper;
+    }
 
     /**
      * タカラトミーアーツサイトのスクレイピングを手動実行

--- a/backend/src/main/java/com/example/capsuletoy/controller/scrape/log/ScrapeLogController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/scrape/log/ScrapeLogController.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,8 +20,11 @@ import com.example.capsuletoy.model.ScrapeLog;
 public class ScrapeLogController {
     private static final Logger logger = LoggerFactory.getLogger(ScrapeLogController.class);
 
-    @Autowired
-    private ScrapeLogAdministrater scrapeLogAdministrater;
+    private final ScrapeLogAdministrater scrapeLogAdministrater;
+
+    public ScrapeLogController(ScrapeLogAdministrater scrapeLogAdministrater) {
+        this.scrapeLogAdministrater = scrapeLogAdministrater;
+    }
 
      /**
      * スクレイピングログの取得

--- a/backend/src/main/java/com/example/capsuletoy/controller/scrape/status/ScrapeStatusController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/scrape/status/ScrapeStatusController.java
@@ -3,7 +3,6 @@ package com.example.capsuletoy.controller.scrape.status;
 import com.example.capsuletoy.domain.log.ScrapeLogAdministrater;
 import com.example.capsuletoy.model.ScrapeLog;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,8 +17,11 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/scrape")
 public class ScrapeStatusController {
-    @Autowired
-    private ScrapeLogAdministrater scrapeLogAdministrater;
+    private final ScrapeLogAdministrater scrapeLogAdministrater;
+
+    public ScrapeStatusController(ScrapeLogAdministrater scrapeLogAdministrater) {
+        this.scrapeLogAdministrater = scrapeLogAdministrater;
+    }
 
     /**
      * スクレイピングステータス確認

--- a/backend/src/main/java/com/example/capsuletoy/controller/scrapeConfig/ScrapeConfigController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/scrapeConfig/ScrapeConfigController.java
@@ -4,7 +4,6 @@ import com.example.capsuletoy.model.ScrapeConfig;
 import com.example.capsuletoy.response.ErrorResponse;
 import com.example.capsuletoy.service.scrapeConfig.ScrapeConfigService;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,8 +17,11 @@ import java.util.List;
 @RequestMapping("/api/scrape/configs")
 @CrossOrigin(origins = "http://localhost:3000")
 public class ScrapeConfigController {
-    @Autowired
-    private ScrapeConfigService scrapeConfigService;
+    private final ScrapeConfigService scrapeConfigService;
+
+    public ScrapeConfigController(ScrapeConfigService scrapeConfigService) {
+        this.scrapeConfigService = scrapeConfigService;
+    }
 
     /**
      * 全設定一覧を取得

--- a/backend/src/main/java/com/example/capsuletoy/controller/scrapeConfig/ScrapeConfigCreate.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/scrapeConfig/ScrapeConfigCreate.java
@@ -1,6 +1,5 @@
 package com.example.capsuletoy.controller.scrapeConfig;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,8 +14,11 @@ import com.example.capsuletoy.service.scrapeConfig.ScrapeConfigCreateService;
 @RestController
 @RequestMapping("/api/scrape/configs")
 public class ScrapeConfigCreate {
-    @Autowired
-    private ScrapeConfigCreateService scrapeConfigCreateService;
+    private final ScrapeConfigCreateService scrapeConfigCreateService;
+
+    public ScrapeConfigCreate(ScrapeConfigCreateService scrapeConfigCreateService) {
+        this.scrapeConfigCreateService = scrapeConfigCreateService;
+    }
 
     /**
      * 新規設定を作成

--- a/backend/src/main/java/com/example/capsuletoy/controller/scrapeConfig/ScrapeConfigDeleteController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/scrapeConfig/ScrapeConfigDeleteController.java
@@ -3,7 +3,6 @@ package com.example.capsuletoy.controller.scrapeConfig;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,8 +16,11 @@ import com.example.capsuletoy.service.scrapeConfig.ScrapeConfigDeleteService;
 @RestController
 @RequestMapping("/api/scrape/configs")
 public class ScrapeConfigDeleteController {
-    @Autowired
-    private ScrapeConfigDeleteService scrapeConfigDeleteService;
+    private final ScrapeConfigDeleteService scrapeConfigDeleteService;
+
+    public ScrapeConfigDeleteController(ScrapeConfigDeleteService scrapeConfigDeleteService) {
+        this.scrapeConfigDeleteService = scrapeConfigDeleteService;
+    }
 
     /**
      * 設定を削除

--- a/backend/src/main/java/com/example/capsuletoy/controller/scrapeConfig/ScrapeConfigEditController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/scrapeConfig/ScrapeConfigEditController.java
@@ -1,6 +1,5 @@
 package com.example.capsuletoy.controller.scrapeConfig;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -17,8 +16,11 @@ import com.example.capsuletoy.service.scrapeConfig.ScrapeConfigUpdateService;
 @RestController
 @RequestMapping("/api/scrape/configs")
 public class ScrapeConfigEditController {
-    @Autowired
-    private ScrapeConfigUpdateService scrapeConfigUpdateService;
+    private final ScrapeConfigUpdateService scrapeConfigUpdateService;
+
+    public ScrapeConfigEditController(ScrapeConfigUpdateService scrapeConfigUpdateService) {
+        this.scrapeConfigUpdateService = scrapeConfigUpdateService;
+    }
 
     /**
      * 設定を更新

--- a/backend/src/main/java/com/example/capsuletoy/controller/user/AdminUserController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/user/AdminUserController.java
@@ -4,7 +4,6 @@ import com.example.capsuletoy.model.User;
 import com.example.capsuletoy.response.user.UserResponse;
 import com.example.capsuletoy.service.user.UserService;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,8 +17,11 @@ import java.util.stream.Stream;
 @RequestMapping("/api/admin/users")
 public class AdminUserController {
 
-    @Autowired
-    private UserService userService;
+    private final UserService userService;
+
+    public AdminUserController(UserService userService) {
+        this.userService = userService;
+    }
 
     // ユーザー一覧取得
     @GetMapping

--- a/backend/src/main/java/com/example/capsuletoy/controller/user/AdminUserCreateController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/user/AdminUserCreateController.java
@@ -2,7 +2,6 @@ package com.example.capsuletoy.controller.user;
 
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
@@ -20,8 +19,11 @@ import com.example.capsuletoy.service.user.UserCreateService;
 @RestController
 @RequestMapping("/api/admin/users")
 public class AdminUserCreateController {
-    @Autowired
-    private UserCreateService userCreateService;
+    private final UserCreateService userCreateService;
+
+    public AdminUserCreateController(UserCreateService userCreateService) {
+        this.userCreateService = userCreateService;
+    }
 
     // ユーザー作成
     @PostMapping

--- a/backend/src/main/java/com/example/capsuletoy/controller/user/AdminUserDeleteController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/user/AdminUserDeleteController.java
@@ -2,7 +2,6 @@ package com.example.capsuletoy.controller.user;
 
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,8 +14,11 @@ import com.example.capsuletoy.service.user.UserDeleteService;
 @RestController
 @RequestMapping("/api/admin/users")
 public class AdminUserDeleteController {
-    @Autowired
-    private UserDeleteService userDeleteService;
+    private final UserDeleteService userDeleteService;
+
+    public AdminUserDeleteController(UserDeleteService userDeleteService) {
+        this.userDeleteService = userDeleteService;
+    }
 
     // ユーザー削除
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/example/capsuletoy/controller/user/AdminUserUpdateController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/user/AdminUserUpdateController.java
@@ -2,7 +2,6 @@ package com.example.capsuletoy.controller.user;
 
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -18,8 +17,11 @@ import com.example.capsuletoy.service.user.UserUpdateService;
 @RestController
 @RequestMapping("/api/admin/users")
 public class AdminUserUpdateController {
-    @Autowired
-    private UserUpdateService userUpdateService;
+    private final UserUpdateService userUpdateService;
+
+    public AdminUserUpdateController(UserUpdateService userUpdateService) {
+        this.userUpdateService = userUpdateService;
+    }
 
     // ユーザー更新
     @PutMapping("/{id}")

--- a/backend/src/main/java/com/example/capsuletoy/controller/user/ProfileController.java
+++ b/backend/src/main/java/com/example/capsuletoy/controller/user/ProfileController.java
@@ -5,7 +5,6 @@ import com.example.capsuletoy.request.user.UpdateUserRequest;
 import com.example.capsuletoy.service.user.UserService;
 import com.example.capsuletoy.service.user.UserUpdateService;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -17,11 +16,14 @@ import java.util.Map;
 @RequestMapping("/api/profile")
 public class ProfileController {
 
-    @Autowired
-    private UserService userService;
+    private final UserService userService;
 
-    @Autowired 
-    private UserUpdateService userUpdateService;
+    private final UserUpdateService userUpdateService;
+
+    public ProfileController(UserService userService, UserUpdateService userUpdateService) {
+        this.userService = userService;
+        this.userUpdateService = userUpdateService;
+    }
 
     // 自分のプロフィール取得
     @GetMapping

--- a/backend/src/main/java/com/example/capsuletoy/domain/auth/AuthenticationUser.java
+++ b/backend/src/main/java/com/example/capsuletoy/domain/auth/AuthenticationUser.java
@@ -1,6 +1,5 @@
 package com.example.capsuletoy.domain.auth;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
@@ -10,8 +9,11 @@ import com.example.capsuletoy.model.UserRole;
 
 @Component
 public class AuthenticationUser {
-    @Autowired
-    private AuthenticationManager authenticationManager;
+    private final AuthenticationManager authenticationManager;
+
+    public AuthenticationUser(AuthenticationManager authenticationManager) {
+        this.authenticationManager = authenticationManager;
+    }
 
     public void authenticate(String email, String password) {
         authenticationManager.authenticate(

--- a/backend/src/main/java/com/example/capsuletoy/domain/configAdmin/ScrapingConfigChecker.java
+++ b/backend/src/main/java/com/example/capsuletoy/domain/configAdmin/ScrapingConfigChecker.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.example.capsuletoy.model.ScrapeConfig;
@@ -15,8 +14,11 @@ import com.example.capsuletoy.service.scheduled.ScheduledScrapeService;
 public class ScrapingConfigChecker {
     private static final Logger logger = LoggerFactory.getLogger(ScheduledScrapeService.class);
 
-    @Autowired
-    ScrapeConfigRepository scrapeConfigRepository;
+    private final ScrapeConfigRepository scrapeConfigRepository;
+
+    public ScrapingConfigChecker(ScrapeConfigRepository scrapeConfigRepository) {
+        this.scrapeConfigRepository = scrapeConfigRepository;
+    }
 
     public List<ScrapeConfig> checkEnabledConfig(){
         List<ScrapeConfig> enabledConfigs = scrapeConfigRepository.findByIsEnabledTrue();

--- a/backend/src/main/java/com/example/capsuletoy/domain/log/ScrapeLogAdministrater.java
+++ b/backend/src/main/java/com/example/capsuletoy/domain/log/ScrapeLogAdministrater.java
@@ -1,6 +1,5 @@
 package com.example.capsuletoy.domain.log;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.example.capsuletoy.model.ScrapeLog;
@@ -11,8 +10,11 @@ import java.util.List;
 
 @Component
 public class ScrapeLogAdministrater {
-    @Autowired
-    private ScrapeLogRepository scrapeLogRepository;
+    private final ScrapeLogRepository scrapeLogRepository;
+
+    public ScrapeLogAdministrater(ScrapeLogRepository scrapeLogRepository) {
+        this.scrapeLogRepository = scrapeLogRepository;
+    }
 
 
     public ScrapeLog getDefaultScrapeLog(String targetSite){

--- a/backend/src/main/java/com/example/capsuletoy/domain/notification/SendEmailDomain.java
+++ b/backend/src/main/java/com/example/capsuletoy/domain/notification/SendEmailDomain.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
@@ -20,20 +19,25 @@ import jakarta.mail.internet.MimeMessage;
 public class SendEmailDomain {
     private static final Logger logger = LoggerFactory.getLogger(SendEmailDomain.class);
 
-    @Autowired
-    private NotificationFromAddressDomain notificationFromAdressDomain;
-    
-    @Autowired
-    private JavaMailSender mailSender;
+    private final NotificationFromAddressDomain notificationFromAdressDomain;
 
-    @Autowired
-    private NotificationEnabledDomain notificationEnabledDomain;
+    private final JavaMailSender mailSender;
 
-    @Autowired
-    private UserRepository userRepository;
+    private final NotificationEnabledDomain notificationEnabledDomain;
 
-    @Autowired
-    private CreateHtmlMainDomain createHtmlMainDomain;
+    private final UserRepository userRepository;
+
+    private final CreateHtmlMainDomain createHtmlMainDomain;
+
+    public SendEmailDomain(NotificationFromAddressDomain notificationFromAdressDomain, JavaMailSender mailSender,
+            NotificationEnabledDomain notificationEnabledDomain, UserRepository userRepository,
+            CreateHtmlMainDomain createHtmlMainDomain) {
+        this.notificationFromAdressDomain = notificationFromAdressDomain;
+        this.mailSender = mailSender;
+        this.notificationEnabledDomain = notificationEnabledDomain;
+        this.userRepository = userRepository;
+        this.createHtmlMainDomain = createHtmlMainDomain;
+    }
 
     /**
      * 新着商品を通知有効ユーザー全員にメール送信

--- a/backend/src/main/java/com/example/capsuletoy/domain/passwordEncode/PasswordEncodeHelper.java
+++ b/backend/src/main/java/com/example/capsuletoy/domain/passwordEncode/PasswordEncodeHelper.java
@@ -1,13 +1,15 @@
 package com.example.capsuletoy.domain.passwordEncode;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PasswordEncodeHelper {
-    @Autowired
-    private BCryptPasswordEncoder passwordEncoder;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public PasswordEncodeHelper(BCryptPasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+    }
 
     public String encodePassword(String password){
         return passwordEncoder.encode(password);

--- a/backend/src/main/java/com/example/capsuletoy/domain/product/DuplicateChecker.java
+++ b/backend/src/main/java/com/example/capsuletoy/domain/product/DuplicateChecker.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.example.capsuletoy.model.Product;
@@ -13,8 +12,11 @@ import com.example.capsuletoy.repository.ProductRepository;
 @Component
 public class DuplicateChecker {
 
-    @Autowired
-    ProductRepository productRepository;
+    private final ProductRepository productRepository;
+
+    public DuplicateChecker(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
 
     // 重複チェック（商品名とメーカーで判定）
     public boolean isDuplicate(String productName, String manufacturer) {

--- a/backend/src/main/java/com/example/capsuletoy/domain/product/NewFlagsAdmin.java
+++ b/backend/src/main/java/com/example/capsuletoy/domain/product/NewFlagsAdmin.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.example.capsuletoy.model.Product;
@@ -14,8 +13,11 @@ import jakarta.transaction.Transactional;
 
 @Component
 public class NewFlagsAdmin {
-    @Autowired
-    ProductRepository productRepository;
+    private final ProductRepository productRepository;
+
+    public NewFlagsAdmin(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
 
      // 新着フラグを更新
     @Transactional

--- a/backend/src/main/java/com/example/capsuletoy/domain/scraping/ManualScrapeExecuter.java
+++ b/backend/src/main/java/com/example/capsuletoy/domain/scraping/ManualScrapeExecuter.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.slf4j.Logger;
@@ -19,8 +18,11 @@ import com.example.capsuletoy.service.scraping.ScrapeService;
 public class ManualScrapeExecuter {
     private static final Logger logger = LoggerFactory.getLogger(ScrapeService.class);
 
-    @Autowired
-    private ProductUpdateService productUpdateService;
+    private final ProductUpdateService productUpdateService;
+
+    public ManualScrapeExecuter(ProductUpdateService productUpdateService) {
+        this.productUpdateService = productUpdateService;
+    }
 
     public List<Product> scrapeProducts(BaseScraper scraper){
         List<Product> scrapedProducts = scraper.scrape();

--- a/backend/src/main/java/com/example/capsuletoy/domain/scraping/RegularScrapeExecuter.java
+++ b/backend/src/main/java/com/example/capsuletoy/domain/scraping/RegularScrapeExecuter.java
@@ -7,7 +7,6 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.example.capsuletoy.model.Product;
@@ -23,17 +22,21 @@ import com.example.capsuletoy.service.scraping.ScrapeService;
 public class RegularScrapeExecuter {
     private static final Logger logger = LoggerFactory.getLogger(ScheduledScrapeService.class);
 
-    @Autowired
-    private ScrapeConfigRepository scrapeConfigRepository;
+    private final ScrapeConfigRepository scrapeConfigRepository;
 
-    @Autowired
-    private BandaiScraper bandaiScraper;
+    private final BandaiScraper bandaiScraper;
 
-    @Autowired
-    private TakaraTomyScraper takaraTomyScraper;
+    private final TakaraTomyScraper takaraTomyScraper;
 
-    @Autowired
-    private ScrapeService scrapeService;
+    private final ScrapeService scrapeService;
+
+    public RegularScrapeExecuter(ScrapeConfigRepository scrapeConfigRepository, BandaiScraper bandaiScraper,
+            TakaraTomyScraper takaraTomyScraper, ScrapeService scrapeService) {
+        this.scrapeConfigRepository = scrapeConfigRepository;
+        this.bandaiScraper = bandaiScraper;
+        this.takaraTomyScraper = takaraTomyScraper;
+        this.scrapeService = scrapeService;
+    }
 
     public List<Product> executeScraping(List<ScrapeConfig> enabledConfigs){
         List<Product> allNewProducts = new ArrayList<>();

--- a/backend/src/main/java/com/example/capsuletoy/repository/ProductRepository.java
+++ b/backend/src/main/java/com/example/capsuletoy/repository/ProductRepository.java
@@ -6,11 +6,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     // メーカー別で検索

--- a/backend/src/main/java/com/example/capsuletoy/repository/ScrapeConfigRepository.java
+++ b/backend/src/main/java/com/example/capsuletoy/repository/ScrapeConfigRepository.java
@@ -2,11 +2,9 @@ package com.example.capsuletoy.repository;
 
 import com.example.capsuletoy.model.ScrapeConfig;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public interface ScrapeConfigRepository extends JpaRepository<ScrapeConfig, Long> {
 
     // 有効な設定のみ取得

--- a/backend/src/main/java/com/example/capsuletoy/repository/ScrapeLogRepository.java
+++ b/backend/src/main/java/com/example/capsuletoy/repository/ScrapeLogRepository.java
@@ -2,11 +2,9 @@ package com.example.capsuletoy.repository;
 
 import com.example.capsuletoy.model.ScrapeLog;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 public interface ScrapeLogRepository extends JpaRepository<ScrapeLog, Long> {
 
     // 対象サイト別でログを取得

--- a/backend/src/main/java/com/example/capsuletoy/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/capsuletoy/repository/UserRepository.java
@@ -3,12 +3,10 @@ package com.example.capsuletoy.repository;
 import com.example.capsuletoy.model.User;
 import com.example.capsuletoy.model.UserRole;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
-@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     // ユーザー名で検索

--- a/backend/src/main/java/com/example/capsuletoy/runner/ScrapeCommandRunner.java
+++ b/backend/src/main/java/com/example/capsuletoy/runner/ScrapeCommandRunner.java
@@ -9,7 +9,6 @@ import com.example.capsuletoy.service.notification.NotificationService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -26,17 +25,21 @@ public class ScrapeCommandRunner implements CommandLineRunner {
 
     private static final Logger logger = LoggerFactory.getLogger(ScrapeCommandRunner.class);
 
-    @Autowired
-    private ScrapingConfigChecker scrapingConfigChecker;
+    private final ScrapingConfigChecker scrapingConfigChecker;
 
-    @Autowired
-    private NewFlagsAdmin newFlagsAdmin;
+    private final NewFlagsAdmin newFlagsAdmin;
 
-    @Autowired
-    private RegularScrapeExecuter scrapeExecuter;
+    private final RegularScrapeExecuter scrapeExecuter;
 
-    @Autowired
-    private NotificationService notificationService;
+    private final NotificationService notificationService;
+
+    public ScrapeCommandRunner(ScrapingConfigChecker scrapingConfigChecker, NewFlagsAdmin newFlagsAdmin,
+            RegularScrapeExecuter scrapeExecuter, NotificationService notificationService) {
+        this.scrapingConfigChecker = scrapingConfigChecker;
+        this.newFlagsAdmin = newFlagsAdmin;
+        this.scrapeExecuter = scrapeExecuter;
+        this.notificationService = notificationService;
+    }
 
     @Override
     public void run(String... args) throws Exception {

--- a/backend/src/main/java/com/example/capsuletoy/scraper/BandaiScraper.java
+++ b/backend/src/main/java/com/example/capsuletoy/scraper/BandaiScraper.java
@@ -34,6 +34,10 @@ public class BandaiScraper extends BaseScraper {
     // 重複チェック用
     private Set<String> processedUrls;
 
+    public BandaiScraper(ScraperConfig scraperConfig) {
+        super(scraperConfig);
+    }
+
     @Override
     protected String getTargetUrl() {
         return TARGET_URL;

--- a/backend/src/main/java/com/example/capsuletoy/scraper/BaseScraper.java
+++ b/backend/src/main/java/com/example/capsuletoy/scraper/BaseScraper.java
@@ -8,7 +8,6 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -22,11 +21,14 @@ public abstract class BaseScraper {
 
     private static final Logger logger = LoggerFactory.getLogger(BaseScraper.class);
 
-    @Autowired
-    protected ScraperConfig scraperConfig;
+    protected final ScraperConfig scraperConfig;
 
     protected WebDriver driver;
     protected WebDriverWait wait;
+
+    protected BaseScraper(ScraperConfig scraperConfig) {
+        this.scraperConfig = scraperConfig;
+    }
 
     /**
      * スクレイピング実行

--- a/backend/src/main/java/com/example/capsuletoy/scraper/TakaraTomyScraper.java
+++ b/backend/src/main/java/com/example/capsuletoy/scraper/TakaraTomyScraper.java
@@ -35,6 +35,10 @@ public class TakaraTomyScraper extends BaseScraper {
     // 重複チェック用（複数ページ間で共有）
     private Set<String> processedUrls;
 
+    public TakaraTomyScraper(ScraperConfig scraperConfig) {
+        super(scraperConfig);
+    }
+
     @Override
     protected String getTargetUrl() {
         // 今月のカレンダーURLを返す（テスト用）

--- a/backend/src/main/java/com/example/capsuletoy/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/capsuletoy/security/JwtAuthenticationFilter.java
@@ -4,7 +4,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -18,11 +17,14 @@ import java.io.IOException;
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    @Autowired
-    private JwtUtil jwtUtil;
+    private final JwtUtil jwtUtil;
 
-    @Autowired
-    private UserDetailsService userDetailsService;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, UserDetailsService userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/backend/src/main/java/com/example/capsuletoy/service/auth/AuthService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/auth/AuthService.java
@@ -2,7 +2,6 @@ package com.example.capsuletoy.service.auth;
 
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.stereotype.Service;
@@ -17,14 +16,17 @@ import com.example.capsuletoy.service.user.UserService;
 @Service
 public class AuthService {
     
-    @Autowired
-    private AuthenticationUser authenticationUser;
+    private final AuthenticationUser authenticationUser;
 
-    @Autowired
-    private UserService userService;
+    private final UserService userService;
 
-    @Autowired
-    private JwtUtil jwtUtil;
+    private final JwtUtil jwtUtil;
+
+    public AuthService(AuthenticationUser authenticationUser, UserService userService, JwtUtil jwtUtil) {
+        this.authenticationUser = authenticationUser;
+        this.userService = userService;
+        this.jwtUtil = jwtUtil;
+    }
 
     public Map<String, Object> adminLogin(String email, String password){
         try{

--- a/backend/src/main/java/com/example/capsuletoy/service/notification/NotificationService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/notification/NotificationService.java
@@ -8,7 +8,6 @@ import com.example.capsuletoy.service.user.UserService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,14 +17,18 @@ public class NotificationService {
 
     private static final Logger logger = LoggerFactory.getLogger(NotificationService.class);
 
-    @Autowired
-    private SendEmailDomain sendEmailDomain;
+    private final SendEmailDomain sendEmailDomain;
 
-    @Autowired
-    private UserService userService;
+    private final UserService userService;
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
+
+    public NotificationService(SendEmailDomain sendEmailDomain, UserService userService,
+            UserRepository userRepository) {
+        this.sendEmailDomain = sendEmailDomain;
+        this.userService = userService;
+        this.userRepository = userRepository;
+    }
 
     public void sendFinishedEmail(List<Product> allnewProducts){
         // スクレイピング完了後に通知メールを送信（新着0件でも送信）

--- a/backend/src/main/java/com/example/capsuletoy/service/product/ProductDeleteService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/product/ProductDeleteService.java
@@ -1,6 +1,5 @@
 package com.example.capsuletoy.service.product;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.example.capsuletoy.repository.ProductRepository;
@@ -9,8 +8,11 @@ import jakarta.transaction.Transactional;
 
 @Service
 public class ProductDeleteService {
-    @Autowired
-    ProductRepository productRepository;
+    private final ProductRepository productRepository;
+
+    public ProductDeleteService(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
 
     // 商品削除
     @Transactional

--- a/backend/src/main/java/com/example/capsuletoy/service/product/ProductPagenationService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/product/ProductPagenationService.java
@@ -1,6 +1,5 @@
 package com.example.capsuletoy.service.product;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -12,8 +11,11 @@ import com.example.capsuletoy.repository.ProductRepository;
 
 @Service
 public class ProductPagenationService {
-    @Autowired
-    ProductRepository productRepository;
+    private final ProductRepository productRepository;
+
+    public ProductPagenationService(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
 
     // ページネーション対応の商品取得
     private Page<Product> getAllProducts(Pageable pageable) {

--- a/backend/src/main/java/com/example/capsuletoy/service/product/ProductService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/product/ProductService.java
@@ -3,7 +3,6 @@ package com.example.capsuletoy.service.product;
 import com.example.capsuletoy.domain.product.DuplicateChecker;
 import com.example.capsuletoy.model.Product;
 import com.example.capsuletoy.repository.ProductRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -12,11 +11,14 @@ import java.util.Optional;
 @Service
 public class ProductService {
 
-    @Autowired
-    private ProductRepository productRepository;
+    private final ProductRepository productRepository;
 
-    @Autowired
-    DuplicateChecker duplicateChecker;
+    private final DuplicateChecker duplicateChecker;
+
+    public ProductService(ProductRepository productRepository, DuplicateChecker duplicateChecker) {
+        this.productRepository = productRepository;
+        this.duplicateChecker = duplicateChecker;
+    }
 
     // 全商品取得
     public List<Product> getAllProducts() {

--- a/backend/src/main/java/com/example/capsuletoy/service/product/ProductUpdateService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/product/ProductUpdateService.java
@@ -3,7 +3,6 @@ package com.example.capsuletoy.service.product;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.example.capsuletoy.domain.product.DuplicateChecker;
@@ -15,14 +14,18 @@ import jakarta.transaction.Transactional;
 @Service
 public class ProductUpdateService {
 
-    @Autowired
-    ProductRepository productRepository;
+    private final ProductRepository productRepository;
 
-    @Autowired
-    DuplicateChecker duplicateChecker;
+    private final DuplicateChecker duplicateChecker;
 
-    @Autowired
-    ProductDeleteService productDeleteService;
+    private final ProductDeleteService productDeleteService;
+
+    public ProductUpdateService(ProductRepository productRepository, DuplicateChecker duplicateChecker,
+            ProductDeleteService productDeleteService) {
+        this.productRepository = productRepository;
+        this.duplicateChecker = duplicateChecker;
+        this.productDeleteService = productDeleteService;
+    }
 
     // スクレイピング結果の保存（重複チェック付き）
     @Transactional

--- a/backend/src/main/java/com/example/capsuletoy/service/scheduled/ScheduledScrapeService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/scheduled/ScheduledScrapeService.java
@@ -9,7 +9,6 @@ import com.example.capsuletoy.service.notification.NotificationService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -24,17 +23,21 @@ public class ScheduledScrapeService {
 
     private static final Logger logger = LoggerFactory.getLogger(ScheduledScrapeService.class);
 
-    @Autowired
-    private ScrapingConfigChecker scrapingConfigChecker;
+    private final ScrapingConfigChecker scrapingConfigChecker;
 
-    @Autowired
-    NewFlagsAdmin newFlagsAdmin;
+    private final NewFlagsAdmin newFlagsAdmin;
 
-    @Autowired
-    RegularScrapeExecuter scrapeExecuter;
+    private final RegularScrapeExecuter scrapeExecuter;
 
-    @Autowired
-    private NotificationService notificationService;
+    private final NotificationService notificationService;
+
+    public ScheduledScrapeService(ScrapingConfigChecker scrapingConfigChecker, NewFlagsAdmin newFlagsAdmin,
+            RegularScrapeExecuter scrapeExecuter, NotificationService notificationService) {
+        this.scrapingConfigChecker = scrapingConfigChecker;
+        this.newFlagsAdmin = newFlagsAdmin;
+        this.scrapeExecuter = scrapeExecuter;
+        this.notificationService = notificationService;
+    }
 
     /**
      * 定期スクレイピング実行（デフォルト: 毎日午前6時に実行）

--- a/backend/src/main/java/com/example/capsuletoy/service/scrapeConfig/ScrapeConfigCreateService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/scrapeConfig/ScrapeConfigCreateService.java
@@ -1,6 +1,5 @@
 package com.example.capsuletoy.service.scrapeConfig;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,11 +12,14 @@ import com.example.capsuletoy.repository.ScrapeConfigRepository;
 public class ScrapeConfigCreateService {
     private static final Logger logger = LoggerFactory.getLogger(ScrapeConfigService.class);
 
-    @Autowired
-    private ScrapeConfigRepository scrapeConfigRepository;
+    private final ScrapeConfigRepository scrapeConfigRepository;
 
-    @Autowired
-    private CroneValidater croneValidater;
+    private final CroneValidater croneValidater;
+
+    public ScrapeConfigCreateService(ScrapeConfigRepository scrapeConfigRepository, CroneValidater croneValidater) {
+        this.scrapeConfigRepository = scrapeConfigRepository;
+        this.croneValidater = croneValidater;
+    }
 
     /**
      * 新規設定を作成

--- a/backend/src/main/java/com/example/capsuletoy/service/scrapeConfig/ScrapeConfigDeleteService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/scrapeConfig/ScrapeConfigDeleteService.java
@@ -1,6 +1,5 @@
 package com.example.capsuletoy.service.scrapeConfig;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,11 +11,15 @@ import com.example.capsuletoy.repository.ScrapeConfigRepository;
 public class ScrapeConfigDeleteService {
     private static final Logger logger = LoggerFactory.getLogger(ScrapeConfigDeleteService.class);
 
-    @Autowired
-    private ScrapeConfigService scrapeConfigService;
+    private final ScrapeConfigService scrapeConfigService;
 
-    @Autowired
-    private ScrapeConfigRepository scrapeConfigRepository;
+    private final ScrapeConfigRepository scrapeConfigRepository;
+
+    public ScrapeConfigDeleteService(ScrapeConfigService scrapeConfigService,
+            ScrapeConfigRepository scrapeConfigRepository) {
+        this.scrapeConfigService = scrapeConfigService;
+        this.scrapeConfigRepository = scrapeConfigRepository;
+    }
 
     /**
      * 設定を削除

--- a/backend/src/main/java/com/example/capsuletoy/service/scrapeConfig/ScrapeConfigService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/scrapeConfig/ScrapeConfigService.java
@@ -3,15 +3,17 @@ package com.example.capsuletoy.service.scrapeConfig;
 import com.example.capsuletoy.model.ScrapeConfig;
 import com.example.capsuletoy.repository.ScrapeConfigRepository;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
 public class ScrapeConfigService {
-    @Autowired
-    private ScrapeConfigRepository scrapeConfigRepository;
+    private final ScrapeConfigRepository scrapeConfigRepository;
+
+    public ScrapeConfigService(ScrapeConfigRepository scrapeConfigRepository) {
+        this.scrapeConfigRepository = scrapeConfigRepository;
+    }
 
     /**
      * 全設定を取得

--- a/backend/src/main/java/com/example/capsuletoy/service/scrapeConfig/ScrapeConfigUpdateService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/scrapeConfig/ScrapeConfigUpdateService.java
@@ -1,6 +1,5 @@
 package com.example.capsuletoy.service.scrapeConfig;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.slf4j.Logger;
@@ -14,14 +13,18 @@ import com.example.capsuletoy.repository.ScrapeConfigRepository;
 public class ScrapeConfigUpdateService {
     private static final Logger logger = LoggerFactory.getLogger(ScrapeConfigService.class);
 
-    @Autowired
-    private ScrapeConfigService scrapeConfigService;
+    private final ScrapeConfigService scrapeConfigService;
 
-    @Autowired
-    private CroneValidater croneValidater;
+    private final CroneValidater croneValidater;
 
-    @Autowired
-    private ScrapeConfigRepository scrapeConfigRepository;
+    private final ScrapeConfigRepository scrapeConfigRepository;
+
+    public ScrapeConfigUpdateService(ScrapeConfigService scrapeConfigService, CroneValidater croneValidater,
+            ScrapeConfigRepository scrapeConfigRepository) {
+        this.scrapeConfigService = scrapeConfigService;
+        this.croneValidater = croneValidater;
+        this.scrapeConfigRepository = scrapeConfigRepository;
+    }
 
     /**
      * 設定を更新

--- a/backend/src/main/java/com/example/capsuletoy/service/scraping/ScrapeService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/scraping/ScrapeService.java
@@ -11,7 +11,6 @@ import com.example.capsuletoy.scraper.BaseScraper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,14 +22,18 @@ public class ScrapeService {
 
     private static final Logger logger = LoggerFactory.getLogger(ScrapeService.class);
 
-    @Autowired
-    private ManualScrapeExecuter manualScrapeExecuter;
+    private final ManualScrapeExecuter manualScrapeExecuter;
 
-    @Autowired
-    private ScrapeLogRepository scrapeLogRepository;
+    private final ScrapeLogRepository scrapeLogRepository;
 
-    @Autowired
-    private ScrapeLogAdministrater logAdministrater;
+    private final ScrapeLogAdministrater logAdministrater;
+
+    public ScrapeService(ManualScrapeExecuter manualScrapeExecuter, ScrapeLogRepository scrapeLogRepository,
+            ScrapeLogAdministrater logAdministrater) {
+        this.manualScrapeExecuter = manualScrapeExecuter;
+        this.scrapeLogRepository = scrapeLogRepository;
+        this.logAdministrater = logAdministrater;
+    }
 
     /**
      * スクレイピングを実行してデータベースに保存

--- a/backend/src/main/java/com/example/capsuletoy/service/user/UserCreateService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/user/UserCreateService.java
@@ -1,6 +1,5 @@
 package com.example.capsuletoy.service.user;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.example.capsuletoy.domain.passwordEncode.PasswordEncodeHelper;
@@ -10,11 +9,14 @@ import com.example.capsuletoy.repository.UserRepository;
 
 @Service
 public class UserCreateService {
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
-    @Autowired
-    private PasswordEncodeHelper passwordEncoder;
+    private final PasswordEncodeHelper passwordEncoder;
+
+    public UserCreateService(UserRepository userRepository, PasswordEncodeHelper passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
 
     // ユーザー作成（管理者用）
     public User createUser(String username, String email, String password, UserRole role) {

--- a/backend/src/main/java/com/example/capsuletoy/service/user/UserDeleteService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/user/UserDeleteService.java
@@ -1,14 +1,16 @@
 package com.example.capsuletoy.service.user;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.example.capsuletoy.repository.UserRepository;
 
 @Service
 public class UserDeleteService {
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
+
+    public UserDeleteService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
 
     // ユーザー削除
     public void deleteUser(Long id) {

--- a/backend/src/main/java/com/example/capsuletoy/service/user/UserService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/user/UserService.java
@@ -2,7 +2,6 @@ package com.example.capsuletoy.service.user;
 
 import com.example.capsuletoy.model.User;
 import com.example.capsuletoy.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -16,11 +15,14 @@ import java.util.List;
 @Service
 public class UserService implements UserDetailsService {
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
-    @Autowired
-    private BCryptPasswordEncoder passwordEncoder;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, BCryptPasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {

--- a/backend/src/main/java/com/example/capsuletoy/service/user/UserUpdateService.java
+++ b/backend/src/main/java/com/example/capsuletoy/service/user/UserUpdateService.java
@@ -1,6 +1,5 @@
 package com.example.capsuletoy.service.user;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.example.capsuletoy.domain.passwordEncode.PasswordEncodeHelper;
@@ -9,14 +8,18 @@ import com.example.capsuletoy.repository.UserRepository;
 
 @Service
 public class UserUpdateService {
-    @Autowired
-    private UserService userService;
+    private final UserService userService;
 
-    @Autowired
-    private UserRepository userRepository;
+    private final UserRepository userRepository;
 
-    @Autowired
-    private PasswordEncodeHelper passwordEncoder;
+    private final PasswordEncodeHelper passwordEncoder;
+
+    public UserUpdateService(UserService userService, UserRepository userRepository,
+            PasswordEncodeHelper passwordEncoder) {
+        this.userService = userService;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
 
     // ユーザー更新
     public User updateUser(Long id, String username, String email, String password, Boolean notificationEnabled) {


### PR DESCRIPTION
## 概要
Spring Boot 拡張機能の警告（`JAVA_CONSTRUCTOR_PARAMETER_INJECTION` / `JAVA_REPOSITORY`）に対応し、依存性注入まわりをベストプラクティスに揃えました。

## 変更内容
### 1. フィールドインジェクション → コンストラクタインジェクション
- `@Autowired` によるフィールドインジェクションを全てコンストラクタインジェクションに変更
- フィールドを `final` 化し、不変・必須依存を保証
- `BaseScraper`（抽象クラス）に `protected` コンストラクタを追加し、継承先の `BandaiScraper` / `TakaraTomyScraper` に `super(...)` を呼ぶコンストラクタを追加
- `SecurityConfig` は `@Value` フィールドを維持しつつ `@Autowired` のみコンストラクタ化

### 2. 不要な @Repository の削除
- `JpaRepository` を継承した4つの Repository インターフェースから、冗長な `@Repository` アノテーションと import を削除

## 動作への影響
- 依存性注入の結果は変わらず、動作は同一
- `mvn clean compile` で BUILD SUCCESS を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)